### PR TITLE
fix: ensure proper UTF-8 handling when indexing trace content

### DIFF
--- a/crates/umem_search/src/trace_index.rs
+++ b/crates/umem_search/src/trace_index.rs
@@ -25,7 +25,7 @@ impl TraceIndex {
         let schema = index.schema();
         let mut index_writer = index.writer_with_num_threads(num_cpus::get() / 2, 100_000_000)?;
         index_writer.add_document(doc!(
-            schema.get_field(CONTENT)? => &trace.content[..]
+            schema.get_field(CONTENT)? => *String::from_utf8_lossy(&trace.content[..])
         ))?;
         index_writer.commit()?;
         index_writer.wait_merging_threads()?;

--- a/crates/umem_search/src/trace_index.rs
+++ b/crates/umem_search/src/trace_index.rs
@@ -25,7 +25,7 @@ impl TraceIndex {
         let schema = index.schema();
         let mut index_writer = index.writer_with_num_threads(num_cpus::get() / 2, 100_000_000)?;
         index_writer.add_document(doc!(
-            schema.get_field(CONTENT)? => *String::from_utf8_lossy(&trace.content[..])
+            schema.get_field(CONTENT)? => String::from_utf8_lossy(&trace.content[..]).to_string()
         ))?;
         index_writer.commit()?;
         index_writer.wait_merging_threads()?;


### PR DESCRIPTION
Replaced direct use of byte slice with String::from_utf8_lossy to properly handle potential non-UTF8 content in trace data before indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of document content with invalid UTF-8 by converting raw bytes to a UTF-8 string with replacement characters where necessary, ensuring better display and search reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->