### PR TITLE
Add a rust-toolchain file to dictate the rust version to use in the folder

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable-aarch64-apple-darwin"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable-aarch64-apple-darwin"
+channel = "stable"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added configuration to specify the Rust toolchain channel for Apple Silicon (ARM64) macOS systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->