### PR TITLE
refactor(auth): update OAuth implementation for WorkOS AuthKit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,11 +35,11 @@ jobs:
     
     - name: Build (Release)
       if: github.ref == 'refs/heads/main'
-      run: cargo build --release --verbose
+      run: cargo build --release
     
     - name: Build (Debug)
       if: github.ref != 'refs/heads/main'
-      run: cargo build --verbose
+      run: cargo build
     
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test

--- a/crates/umem_mcp/src/lib.rs
+++ b/crates/umem_mcp/src/lib.rs
@@ -259,14 +259,13 @@ pub struct ProtectedResourceInner {
 }
 
 async fn oauth_protected_resource_server() -> impl IntoResponse {
-    let workos_authkit_url = std::env::var("WORKOS_AUTHKIT_URL")
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "WORKOS_AUTHKIT_URL not set",
-            )
-        })
-        .unwrap();
+     let workos_authkit_url = match std::env::var("WORKOS_AUTHKIT_URL") {
+         Ok(url) => url,
+         Err(_) => {
+             return (StatusCode::INTERNAL_SERVER_ERROR, "WORKOS_AUTHKIT_URL not set")
+                 .into_response();
+         }
+     };
 
     let metadata = json!({
         "resource": REMOTE_ADDRESS,

--- a/crates/umem_mcp/src/lib.rs
+++ b/crates/umem_mcp/src/lib.rs
@@ -259,13 +259,16 @@ pub struct ProtectedResourceInner {
 }
 
 async fn oauth_protected_resource_server() -> impl IntoResponse {
-     let workos_authkit_url = match std::env::var("WORKOS_AUTHKIT_URL") {
-         Ok(url) => url,
-         Err(_) => {
-             return (StatusCode::INTERNAL_SERVER_ERROR, "WORKOS_AUTHKIT_URL not set")
-                 .into_response();
-         }
-     };
+    let workos_authkit_url = match std::env::var("WORKOS_AUTHKIT_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "WORKOS_AUTHKIT_URL not set",
+            )
+                .into_response();
+        }
+    };
 
     let metadata = json!({
         "resource": REMOTE_ADDRESS,
@@ -274,7 +277,7 @@ async fn oauth_protected_resource_server() -> impl IntoResponse {
     });
 
     debug!("metadata: {:?}", metadata);
-    (StatusCode::OK, Json(metadata))
+    (StatusCode::OK, Json(metadata)).into_response()
 }
 
 async fn oauth_authorization_server() -> impl IntoResponse {

--- a/crates/umem_mcp/src/token.rs
+++ b/crates/umem_mcp/src/token.rs
@@ -45,7 +45,7 @@ pub async fn check_token(token: &str, keys: &JWKS) -> Result<TokenData<Claims>, 
         .map_err(|op| format!("Decoding Key Error: {:?}", op))?;
 
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
-    validation.set_audience(&[client_id]);
+    validation.set_audience(&[client_id.as_str()]);
 
     let token_data = jsonwebtoken::decode::<Claims>(token, &decoding_key, &validation)
         .map_err(|op| format!("JWT Decode Error: {:?}", op))?;


### PR DESCRIPTION
- Update REMOTE_ADDRESS to use m.evenscribe.com instead of mccp
- Replace static redirect URI with dynamic one using REMOTE_ADDRESS
- Update protected resource and authorization server metadata formats
- Add environment variable requirement for WORKOS_AUTHKIT_URL
- Add client_id validation in token verification
- Remove unused imports (AuthorizationMetadata, Value)
- Add debugging output for JWT verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamable MCP endpoints under /mcp and runtime session-enabled streaming.
  * OAuth metadata and protected-resource endpoints now return dynamic JSON driven by an env-configured authorization server URL.

* **Bug Fixes**
  * Stricter JWT validation enforcing audience from WORKOS_CLIENT_ID.
  * Clearer errors when required environment variables are missing; removed some debug output.

* **Chores**
  * Updated OAuth base domain to https://m.evenscribe.com.
  * Streamlined JSON handling and responses.
  * CI: removed verbose flags from cargo commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->