### PR TITLE
feat(umem_mcp): improve error handling and add tokio signal feature

### DIFF
--- a/crates/umem_mcp/Cargo.toml
+++ b/crates/umem_mcp/Cargo.toml
@@ -10,7 +10,7 @@ umem_controller = { workspace = true }
 serde = {workspace = true }
 tonic = "0.12"
 prost = "0.13"
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 rmcp = {workspace = true, features=["auth"] }
 chrono = {workspace = true}
 tracing-subscriber = {version="0.3.19", features = ["env-filter", "fmt"]}


### PR DESCRIPTION
- Add "signal" feature to tokio dependency
- Replace unwraps with proper error handling in McpOAuthStore::new()
- Add robust error handling in OAuth authorization and token endpoints
- Handle serialization/deserialization errors properly
- Improve error messages with specific details about missing parameters
- Remove unused constant ISSUER_WORKOS