### PR TITLE
feat(logging): add HTTP request tracing with tower-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3575,6 +3575,7 @@ dependencies = [
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3651,6 +3652,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",
@@ -3787,6 +3789,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rmcp = { version = "0.3.0", features = ["server", "macros", "transport-io", "tra
 chrono = "0.4.41"
 uuid = { version = "1.17.0", features = ["v4"] }
 base64 = { version = "0.22.1"}
-tracing-subscriber = {version="0.3.19", features = ["env-filter", "fmt"]}
+tracing-subscriber = {version="0.3.19", features = ["env-filter", "fmt", "chrono"]}
 tracing = "0.1.41"
 tracing-appender = "0.2.3"
 dirs = "6.0.0"

--- a/crates/umem_mcp/Cargo.toml
+++ b/crates/umem_mcp/Cargo.toml
@@ -15,7 +15,7 @@ rmcp = {workspace = true, features=["auth"] }
 chrono = {workspace = true}
 axum = {version="0.8.4", features=["macros"]}
 rand = { version = "0.9", features = ["std"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 serde_json = {workspace= true}
 uuid = {workspace=true, features=["v4"]}
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -25,6 +25,8 @@ base64 = { workspace = true}
 jsonwebtoken = "9.3.1"
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
+
+
 
 [dev-dependencies]
 tokio-stream = { version = "0.1" }

--- a/crates/umem_summarizer/Cargo.toml
+++ b/crates/umem_summarizer/Cargo.toml
@@ -9,6 +9,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "lib.rs"

--- a/crates/umem_summarizer/lib.rs
+++ b/crates/umem_summarizer/lib.rs
@@ -109,6 +109,8 @@ impl Summarizer {
 
 #[cfg(test)]
 mod tests {
+    use tracing::debug;
+
     use super::*;
 
     #[tokio::test]
@@ -135,6 +137,6 @@ mod tests {
 
         let result = summarizer.summarize(text, max_length).await;
         assert!(result.is_ok(), "Summarization failed: {:?}", result.err());
-        println!("Summary: {}", result.unwrap().summary);
+        debug!("Summary: {}", result.unwrap().summary);
     }
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -36,10 +36,12 @@ pub fn init_tracing() -> Result<WorkerGuard> {
     let stdout_layer = fmt::layer()
         .with_writer(io::stdout.with_max_level(tracing::Level::INFO))
         .with_ansi(true)
-        .with_target(false)
-        .compact();
+        .with_target(true)
+        .with_timer(fmt::time::ChronoLocal::rfc_3339())
+        .pretty();
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "debug".into());
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "debug,tower_http=info,umem_mcp=info".into());
 
     tracing_subscriber::registry()
         .with(env_filter)


### PR DESCRIPTION
- Add tower-http tracing middleware to both routers
- Configure tracing to include headers and latency metrics
- Add chrono feature to tracing-subscriber for timestamp formatting
- Add user ID header propagation from auth token to request context
- Update logging output format to include timestamps and targets
- Configure default log levels for tower_http and umem_mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - User ID is now propagated from JWT and attached to requests, enabling user-scoped memory creation.
  - Request/response tracing added to HTTP and SSE endpoints for improved observability.

- Chores
  - Updated logging format with timestamps and module targets; adjusted default log filters for clearer output.
  - Expanded tracing and HTTP stack dependencies to support new logging/tracing capabilities.

- Tests
  - Switched test output from println to tracing-based debug logs for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->